### PR TITLE
undefined method `use_in_file_templates!' for main:Object (NoMethodError)

### DIFF
--- a/facebook-oauth-example.rb
+++ b/facebook-oauth-example.rb
@@ -51,7 +51,7 @@ get "/logout" do
   redirect "/"
 end
 
-use_in_file_templates!
+enable :inline_templates
 
 __END__
 


### PR DESCRIPTION
The `use_in_file_templates!` method is obsolete. Using `enable :inline_templates` instead.
